### PR TITLE
Docs: add swagger

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,7 @@
         <mysql-connector-java.version>8.0.33</mysql-connector-java.version>
         <lombok-mapstruct-binding.version>0.2.0</lombok-mapstruct-binding.version>
         <thumbnailator.version>0.4.20</thumbnailator.version>
+        <springdoc.version>2.8.4</springdoc.version>
     </properties>
 
     <dependencies>
@@ -78,6 +79,17 @@
             <version>${thumbnailator.version}</version>
         </dependency>
 
+        <dependency>
+            <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+            <version>${springdoc.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+        </dependency>
+ 
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>

--- a/src/main/java/com/openclassrooms/rental/configuration/OpenAPIConfiguration.java
+++ b/src/main/java/com/openclassrooms/rental/configuration/OpenAPIConfiguration.java
@@ -1,0 +1,32 @@
+package com.openclassrooms.rental.configuration;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Contact;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+
+@Configuration
+public class OpenAPIConfiguration {
+
+    @Bean
+    public OpenAPI customOpenAPI() {
+        Contact contact = new Contact().name("Axel").email("axelker@outlook.fr");
+        Info information = new Info()
+                .title("Rental Management System API")
+                .version("1.0")
+                .description("This API exposes endpoints to manage rentals.")
+                .contact(contact);
+        return new OpenAPI()
+                .info(information)
+                .addSecurityItem(new SecurityRequirement().addList("BearerAuth"))
+                .components(new Components().addSecuritySchemes("BearerAuth", new SecurityScheme()
+                        .name("BearerAuth").type(SecurityScheme.Type.HTTP).scheme("bearer")
+                        .bearerFormat("JWT")));
+
+    }
+}

--- a/src/main/java/com/openclassrooms/rental/configuration/SecurityConfig.java
+++ b/src/main/java/com/openclassrooms/rental/configuration/SecurityConfig.java
@@ -26,7 +26,6 @@ import com.openclassrooms.rental.service.query.UserQueryService;
 @EnableMethodSecurity
 public class SecurityConfig {
 
-    // todo: need to add complet swagger uri to properties
     @Value("${security.publicUrls}")
     private String[] publicUrls;
 

--- a/src/main/java/com/openclassrooms/rental/controller/AuthRestController.java
+++ b/src/main/java/com/openclassrooms/rental/controller/AuthRestController.java
@@ -39,7 +39,7 @@ public class AuthRestController {
         this.authService = authService;
     }
 
-    @Operation(summary = "Get a user info authentication", description = "Retrieve details of a user property using its authentication information.")
+    @Operation(summary = "Find info of current user authenticate", description = "Retrieve details of a user using its authentication information.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "User info found", content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = UserResponse.class))),
             @ApiResponse(responseCode = "401", description = "Unauthorized - Token missing or invalid", content = @Content),

--- a/src/main/java/com/openclassrooms/rental/controller/AuthRestController.java
+++ b/src/main/java/com/openclassrooms/rental/controller/AuthRestController.java
@@ -7,15 +7,29 @@ import org.springframework.web.bind.annotation.RestController;
 import com.openclassrooms.rental.dto.request.AuthLoginRequest;
 import com.openclassrooms.rental.dto.request.AuthRegisterRequest;
 import com.openclassrooms.rental.dto.response.AuthResponse;
+import com.openclassrooms.rental.dto.response.ErrorResponse;
+import com.openclassrooms.rental.dto.response.Response;
 import com.openclassrooms.rental.dto.response.UserResponse;
 import com.openclassrooms.rental.service.auth.AuthenticationService;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
 import org.springframework.web.bind.annotation.RequestBody;
-
-
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.GetMapping;
 
+@Tag(name = "Authentication", description = "User authentication and registration")
+@ApiResponses({
+        @ApiResponse(responseCode = "500", description = "Internal server error", content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = ErrorResponse.class)))
+})
 @RestController
 @RequestMapping("/auth")
 public class AuthRestController {
@@ -25,19 +39,36 @@ public class AuthRestController {
         this.authService = authService;
     }
 
+    @Operation(summary = "Get a user info authentication", description = "Retrieve details of a user property using its authentication information.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "User info found", content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = UserResponse.class))),
+            @ApiResponse(responseCode = "401", description = "Unauthorized - Token missing or invalid", content = @Content),
+            @ApiResponse(responseCode = "404", description = "User not found", content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = ErrorResponse.class))),
+
+    })
     @GetMapping("me")
     public ResponseEntity<UserResponse> getMe(Authentication authentication) {
         return ResponseEntity.ok(authService.getUserInfo(authentication));
     }
 
+    @Operation(summary = "User Login", description = "Authenticate user and return a JWT token.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Login successfully", content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = AuthResponse.class))),
+            @ApiResponse(responseCode = "401", description = "Unauthorized - Invalid credentials", content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = ErrorResponse.class))),
+    })
     @PostMapping("login")
     public ResponseEntity<AuthResponse> login(@RequestBody AuthLoginRequest body) {
         return ResponseEntity.ok(authService.authenticate(body));
     }
 
+    @Operation(summary = "User Registration", description = "Register a new user and return a JWT token.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "201", description = "User register successfully", content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = AuthResponse.class))),
+            @ApiResponse(responseCode = "409", description = "Conflict : User already exist with the same email in the system.", content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = ErrorResponse.class))),
+    })
     @PostMapping("register")
     public ResponseEntity<AuthResponse> register(@RequestBody AuthRegisterRequest body) throws Exception {
-        return ResponseEntity.ok(authService.register(body));
+        return ResponseEntity.status(HttpStatus.CREATED).body(authService.register(body));
     }
 
 }

--- a/src/main/java/com/openclassrooms/rental/controller/MessageRestController.java
+++ b/src/main/java/com/openclassrooms/rental/controller/MessageRestController.java
@@ -4,13 +4,28 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.openclassrooms.rental.dto.request.MessageRequest;
+import com.openclassrooms.rental.dto.response.ErrorResponse;
 import com.openclassrooms.rental.dto.response.Response;
 import com.openclassrooms.rental.service.command.MessageCommandService;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 
+@Tag(name = "Messages", description = "Endpoints for managing messages properties")
+@ApiResponses(value = {
+        @ApiResponse(responseCode = "401", description = "Unauthorized - Token missing or invalid", content = @Content),
+        @ApiResponse(responseCode = "500", description = "Internal server error", content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = ErrorResponse.class)))
+})
 @RestController
 @RequestMapping("/messages")
 public class MessageRestController {
@@ -20,10 +35,17 @@ public class MessageRestController {
         this.messageCommandService = messageCommandService;
     }
 
+    @Operation(summary = "Create a message", description = "Add a new message to the system.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "201", description = "Message created successfully", content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = Response.class))),
+            @ApiResponse(responseCode = "400", description = "Bad Request - Invalid input", content = @Content)
+    })
     @PostMapping("")
     public ResponseEntity<Response> sendMessage(@RequestBody MessageRequest body) {
         this.messageCommandService.createMessage(body);
-        return ResponseEntity.ok(Response.builder().message("Message send with success !").build());
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(Response.builder().message("Message sent successfully!").build());
+
     }
 
 }

--- a/src/main/java/com/openclassrooms/rental/controller/MessageRestController.java
+++ b/src/main/java/com/openclassrooms/rental/controller/MessageRestController.java
@@ -21,7 +21,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 
-@Tag(name = "Messages", description = "Endpoints for managing messages properties")
+@Tag(name = "Messages", description = "Manage messages properties")
 @ApiResponses(value = {
         @ApiResponse(responseCode = "401", description = "Unauthorized - Token missing or invalid", content = @Content),
         @ApiResponse(responseCode = "500", description = "Internal server error", content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = ErrorResponse.class)))

--- a/src/main/java/com/openclassrooms/rental/controller/MessageRestController.java
+++ b/src/main/java/com/openclassrooms/rental/controller/MessageRestController.java
@@ -21,7 +21,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 
-@Tag(name = "Messages", description = "Manage messages properties")
+@Tag(name = "Messages", description = "Manage user messages on rental")
 @ApiResponses(value = {
         @ApiResponse(responseCode = "401", description = "Unauthorized - Token missing or invalid", content = @Content),
         @ApiResponse(responseCode = "500", description = "Internal server error", content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = ErrorResponse.class)))

--- a/src/main/java/com/openclassrooms/rental/controller/RentalRestController.java
+++ b/src/main/java/com/openclassrooms/rental/controller/RentalRestController.java
@@ -5,14 +5,24 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
+import com.openclassrooms.rental.dto.response.ErrorResponse;
 import com.openclassrooms.rental.dto.response.RentalResponse;
 import com.openclassrooms.rental.dto.response.RentalsResponse;
 import com.openclassrooms.rental.dto.response.Response;
 import com.openclassrooms.rental.service.auth.JWTService;
 import com.openclassrooms.rental.service.command.RentalCommandService;
 import com.openclassrooms.rental.service.query.RentalQueryService;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
 import java.io.IOException;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -20,60 +30,81 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 
+@Tag(name = "Rentals", description = "Manage rental properties")
+@ApiResponses(value = {
+                @ApiResponse(responseCode = "401", description = "Unauthorized - Token missing or invalid", content = @Content),
+                @ApiResponse(responseCode = "500", description = "Internal server error", content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = ErrorResponse.class)))
+})
 @RestController
 @RequestMapping("/rentals")
 public class RentalRestController {
 
-    private final RentalQueryService rentalQueryService;
-    private final RentalCommandService rentalCommandService;
-    private final JWTService jwtService;
+        private final RentalQueryService rentalQueryService;
+        private final RentalCommandService rentalCommandService;
+        private final JWTService jwtService;
 
-    public RentalRestController(RentalQueryService rentalQueryService, RentalCommandService rentalCommandService,
-            JWTService jwtService) {
-        this.rentalQueryService = rentalQueryService;
-        this.rentalCommandService = rentalCommandService;
-        this.jwtService = jwtService;
-    }
-
-    @GetMapping("")
-    public ResponseEntity<RentalsResponse> getRentals() {
-        return ResponseEntity.ok(rentalQueryService.getRentals());
-    }
-
-    @GetMapping("{id}")
-    public ResponseEntity<RentalResponse> getRental(@PathVariable Integer id) {
-        return ResponseEntity.ok(rentalQueryService.getRentalById(id));
-    }
-
-    @PostMapping("")
-    public ResponseEntity<Response> createRental(
-            @RequestParam String name,
-            @RequestParam double surface,
-            @RequestParam double price,
-            @RequestParam String description,
-            @RequestParam MultipartFile picture,
-            Authentication authentication) {
-
-        try {
-
-            rentalCommandService.createRental(name, surface, price, description, picture,
-                    jwtService.getUserId(authentication));
-        } catch (IOException e) {
-            return ResponseEntity.internalServerError()
-                    .body(Response.builder().message("Error to save rental image.").build());
+        public RentalRestController(RentalQueryService rentalQueryService, RentalCommandService rentalCommandService,
+                        JWTService jwtService) {
+                this.rentalQueryService = rentalQueryService;
+                this.rentalCommandService = rentalCommandService;
+                this.jwtService = jwtService;
         }
-        return ResponseEntity.status(HttpStatus.CREATED).body(Response.builder().message("Rental created ! ").build());
-    }
 
-    @PutMapping("{id}")
-    public ResponseEntity<Response> updateRental(
-            @PathVariable Integer id,
-            @RequestParam String name,
-            @RequestParam double surface,
-            @RequestParam double price,
-            @RequestParam String description) {
-        rentalCommandService.updateRental(id, name, surface, price, description);
-        return ResponseEntity.ok().body(Response.builder().message("Rental updated !").build());
-    }
+        @Operation(summary = "Retrieve all rentals", description = "Fetch a list of all available rental.")
+        @ApiResponses(value = {
+                        @ApiResponse(responseCode = "200", description = "List of rentals successfully retrieved", content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = RentalsResponse.class))),
+        })
+        @GetMapping("")
+        public ResponseEntity<RentalsResponse> getRentals() {
+                return ResponseEntity.ok(rentalQueryService.getRentals());
+        }
+
+        @Operation(summary = "Find a rental by ID", description = "Retrieve details of a rental property using its ID.")
+        @ApiResponses(value = {
+                        @ApiResponse(responseCode = "200", description = "Rental found", content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = RentalResponse.class))),
+                        @ApiResponse(responseCode = "404", description = "Rental not found", content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = ErrorResponse.class)))
+        })
+        @GetMapping("{id}")
+        public ResponseEntity<RentalResponse> getRental(@PathVariable Integer id) {
+                return ResponseEntity.ok(rentalQueryService.getRentalById(id));
+        }
+
+        @Operation(summary = "Create a new rental", description = "Add a new rental property to the system.")
+        @ApiResponses(value = {
+                        @ApiResponse(responseCode = "201", description = "Rental created successfully", content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = Response.class))),
+                        @ApiResponse(responseCode = "400", description = "Invalid request", content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = ErrorResponse.class))),
+        })
+        @PostMapping("")
+        public ResponseEntity<Response> createRental(
+                        @RequestParam String name,
+                        @RequestParam double surface,
+                        @RequestParam double price,
+                        @RequestParam String description,
+                        @RequestParam MultipartFile picture,
+                        Authentication authentication) throws IOException {
+
+                rentalCommandService.createRental(name, surface, price, description, picture,
+                                jwtService.getUserId(authentication));
+
+                return ResponseEntity.status(HttpStatus.CREATED)
+                                .body(Response.builder().message("Rental created successfully.").build());
+        }
+
+        @Operation(summary = "Update a rental", description = "Modify the details of an existing rental property.")
+        @ApiResponses(value = {
+                        @ApiResponse(responseCode = "200", description = "Rental updated successfully", content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = Response.class))),
+                        @ApiResponse(responseCode = "400", description = "Invalid request", content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = ErrorResponse.class))),
+                        @ApiResponse(responseCode = "404", description = "Rental not found", content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = ErrorResponse.class)))
+        })
+        @PutMapping("{id}")
+        public ResponseEntity<Response> updateRental(
+                        @PathVariable Integer id,
+                        @RequestParam String name,
+                        @RequestParam double surface,
+                        @RequestParam double price,
+                        @RequestParam String description) {
+                rentalCommandService.updateRental(id, name, surface, price, description);
+                return ResponseEntity.ok().body(Response.builder().message("Rental updated successfully.").build());
+        }
 
 }

--- a/src/main/java/com/openclassrooms/rental/controller/StorageRestController.java
+++ b/src/main/java/com/openclassrooms/rental/controller/StorageRestController.java
@@ -1,14 +1,28 @@
 package com.openclassrooms.rental.controller;
 
 import java.io.IOException;
+
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.openclassrooms.rental.dto.response.ErrorResponse;
 import com.openclassrooms.rental.service.storage.ImageStorageService;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name = "Storage", description = "Endpoints for retrieving stored files.")
+@ApiResponses({
+        @ApiResponse(responseCode = "500", description = "Internal server error", content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = ErrorResponse.class)))
+})
 @RestController
 @RequestMapping("/storage")
 public class StorageRestController {
@@ -18,9 +32,16 @@ public class StorageRestController {
         this.imageStorageService = imageStorageService;
     }
 
-    @GetMapping("/images/{fileName}")
-    public ResponseEntity<byte[]> getImage(@PathVariable String fileName) throws IOException {
+    @Operation(summary = "Retrieve an image", description = "Fetches an image from storage by filename.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Image retrieved successfully", content = @Content(mediaType = MediaType.IMAGE_PNG_VALUE)),
+            @ApiResponse(responseCode = "404", description = "Image not found", content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = ErrorResponse.class))),
+    })
+    @GetMapping(value = "/images/{fileName}", produces = { MediaType.IMAGE_PNG_VALUE,
+            MediaType.APPLICATION_JSON_VALUE })
+    public ResponseEntity<?> getImage(@PathVariable String fileName) throws IOException {
         byte[] image = imageStorageService.loadImage(fileName);
-        return ResponseEntity.ok(image);
+        return ResponseEntity.ok().contentType(MediaType.IMAGE_PNG).body(image);
     }
+
 }

--- a/src/main/java/com/openclassrooms/rental/controller/UserRestController.java
+++ b/src/main/java/com/openclassrooms/rental/controller/UserRestController.java
@@ -3,13 +3,27 @@ package com.openclassrooms.rental.controller;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.openclassrooms.rental.dto.response.ErrorResponse;
 import com.openclassrooms.rental.dto.response.UserResponse;
 import com.openclassrooms.rental.service.query.UserQueryService;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 
+@Tag(name = "Users", description = "Endpoints for managing user properties")
+@ApiResponses(value = {
+        @ApiResponse(responseCode = "401", description = "Unauthorized - Token missing or invalid", content = @Content),
+        @ApiResponse(responseCode = "500", description = "Internal server error", content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = ErrorResponse.class)))
+})
 @RestController
 @RequestMapping("/user")
 public class UserRestController {
@@ -20,6 +34,11 @@ public class UserRestController {
         this.userQueryService = userQueryService;
     }
 
+    @Operation(summary = "Get a user by ID", description = "Retrieve details of a user property using its ID.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "User found", content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = UserResponse.class))),
+            @ApiResponse(responseCode = "404", description = "User not found", content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = ErrorResponse.class)))
+    })
     @GetMapping("{id}")
     public ResponseEntity<UserResponse> getUser(@PathVariable Integer id) {
         return ResponseEntity.ok(userQueryService.getUserById(id));

--- a/src/main/java/com/openclassrooms/rental/controller/UserRestController.java
+++ b/src/main/java/com/openclassrooms/rental/controller/UserRestController.java
@@ -19,7 +19,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 
-@Tag(name = "Users", description = "Endpoints for managing user properties")
+@Tag(name = "Users", description = "Manage user accounts")
 @ApiResponses(value = {
         @ApiResponse(responseCode = "401", description = "Unauthorized - Token missing or invalid", content = @Content),
         @ApiResponse(responseCode = "500", description = "Internal server error", content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = ErrorResponse.class)))
@@ -34,7 +34,7 @@ public class UserRestController {
         this.userQueryService = userQueryService;
     }
 
-    @Operation(summary = "Get a user by ID", description = "Retrieve details of a user property using its ID.")
+    @Operation(summary = "Find a user by ID", description = "Retrieve details of a user property using its ID.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "User found", content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = UserResponse.class))),
             @ApiResponse(responseCode = "404", description = "User not found", content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = ErrorResponse.class)))

--- a/src/main/java/com/openclassrooms/rental/dto/response/ErrorResponse.java
+++ b/src/main/java/com/openclassrooms/rental/dto/response/ErrorResponse.java
@@ -1,0 +1,25 @@
+package com.openclassrooms.rental.dto.response;
+
+import java.time.LocalDateTime;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@Schema(description = "Standard error response structure")
+public class ErrorResponse {
+
+    @Schema(description = "Timestamp when the error occurred", example = "2021-01-01T23:30:00")
+    private final LocalDateTime timestamp;
+
+    @Schema(description = "HTTP status code", example = "5XX")
+    private final int status;
+
+    @Schema(description = "Error message", example = "Invalid request parameters")
+    private final String message;
+
+    @Schema(description = "Path of the requested endpoint", example = "/api/5")
+    private final String path;
+
+}

--- a/src/main/java/com/openclassrooms/rental/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/openclassrooms/rental/exception/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package com.openclassrooms.rental.exception;
 
+import java.time.LocalDateTime;
 import java.util.NoSuchElementException;
 
 import org.springframework.http.HttpStatus;
@@ -7,37 +8,48 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.request.WebRequest;
 
+import com.openclassrooms.rental.dto.response.ErrorResponse;
 import com.openclassrooms.rental.exception.user.UserAlreadyExistsException;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
     @ExceptionHandler(NoSuchElementException.class)
-    public ResponseEntity<String> handleNotFound(NoSuchElementException ex) {
-        return new ResponseEntity<>(ex.getMessage(), HttpStatus.NOT_FOUND);
+    public ResponseEntity<ErrorResponse> handleNotFound(NoSuchElementException ex, WebRequest request) {
+        return buildErrorResponse(ex.getMessage(), HttpStatus.NOT_FOUND, request);
     }
 
     @ExceptionHandler(UserAlreadyExistsException.class)
-    public ResponseEntity<String> handleUserAlreadyExists(UserAlreadyExistsException ex) {
-        return ResponseEntity.status(HttpStatus.CONFLICT)
-                .body(ex.getMessage());
+    public ResponseEntity<ErrorResponse> handleUserAlreadyExists(UserAlreadyExistsException ex, WebRequest request) {
+        return buildErrorResponse(ex.getMessage(), HttpStatus.CONFLICT, request);
     }
 
     @ExceptionHandler(BadCredentialsException.class)
-    public ResponseEntity<String> handleBadCredentials(BadCredentialsException ex) {
-        return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
-                .body("Invalid email or password.");
+    public ResponseEntity<ErrorResponse> handleBadCredentials(BadCredentialsException ex, WebRequest request) {
+        return buildErrorResponse("Invalid email or password.", HttpStatus.UNAUTHORIZED, request);
     }
 
     @ExceptionHandler(IllegalArgumentException.class)
-    ResponseEntity<String> handleBadRequestFound(IllegalArgumentException ex) {
-        return new ResponseEntity<>(ex.getMessage(), HttpStatus.BAD_REQUEST);
+    public ResponseEntity<ErrorResponse> handleBadRequestFound(IllegalArgumentException ex, WebRequest request) {
+        return buildErrorResponse(ex.getMessage(), HttpStatus.BAD_REQUEST, request);
     }
 
     @ExceptionHandler(Exception.class)
-    public ResponseEntity<String> handleGenericException(Exception ex) {
-        return new ResponseEntity<>("An unexpected error occurred: " + ex.getMessage(),
-                HttpStatus.INTERNAL_SERVER_ERROR);
+    public ResponseEntity<ErrorResponse> handleGenericException(Exception ex, WebRequest request) {
+        return buildErrorResponse("An unexpected error occurred: " + ex.getMessage(),
+                HttpStatus.INTERNAL_SERVER_ERROR, request);
+    }
+
+    private ResponseEntity<ErrorResponse> buildErrorResponse(String message, HttpStatus status, WebRequest request) {
+        ErrorResponse errorResponse = ErrorResponse.builder()
+                .timestamp(LocalDateTime.now())
+                .status(status.value())
+                .message(message)
+                .path(request.getDescription(false).replace("uri=", ""))
+                .build();
+
+        return ResponseEntity.status(status).body(errorResponse);
     }
 }

--- a/src/main/java/com/openclassrooms/rental/service/command/RentalCommandService.java
+++ b/src/main/java/com/openclassrooms/rental/service/command/RentalCommandService.java
@@ -50,7 +50,7 @@ public class RentalCommandService {
                         String description) throws NoSuchElementException {
 
                 RentalEntity rentalToUpdate = rentalRepository.findById(id)
-                                .orElseThrow(() -> new NoSuchElementException("Rental not found for update"));
+                                .orElseThrow(() -> new NoSuchElementException("Rental not found for update."));
                 rentalRepository.save(rentalToUpdate.toBuilder()
                                 .name(name)
                                 .surface(surface)

--- a/src/main/java/com/openclassrooms/rental/service/storage/ImageStorageService.java
+++ b/src/main/java/com/openclassrooms/rental/service/storage/ImageStorageService.java
@@ -15,6 +15,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
+import java.util.NoSuchElementException;
 import java.util.UUID;
 
 @Service
@@ -44,15 +45,13 @@ public class ImageStorageService {
         return filePath.toString();
     }
 
-    public byte[] loadImage(String fileName) throws IOException {
+    public byte[] loadImage(String fileName) throws NoSuchElementException, IOException {
         Path uploadPath = getUploadDirPath();
         Path filePath = uploadPath.resolve(fileName).normalize();
-
-        if (Files.exists(filePath) && Files.isReadable(filePath)) {
-            return Files.readAllBytes(filePath);
-        } else {
-            throw new IOException("File not found: " + fileName);
+        if (!Files.exists(filePath) || !Files.isReadable(filePath)) {
+            throw new NoSuchElementException("File not found: " + fileName);
         }
+        return Files.readAllBytes(filePath);
     }
 
     private Path getUploadDirPath() {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -18,7 +18,7 @@ spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.format_sql=true
 
 #Endpoints
-security.publicUrls=/auth/login,/auth/register,/swagger-ui/**
+security.publicUrls=/auth/login,/auth/register,/swagger-ui/**,/v3/api-docs/**
 
 #JWT
 jwt.secret=${JWT_SECRET}

--- a/src/test/java/com/openclassrooms/rental/service/command/RentalCommandServiceTest.java
+++ b/src/test/java/com/openclassrooms/rental/service/command/RentalCommandServiceTest.java
@@ -103,6 +103,6 @@ public class RentalCommandServiceTest {
 
         NoSuchElementException ex = assertThrows(NoSuchElementException.class,
                 () -> rentalCommandService.updateRental(rentalId, "New Name", 90.0, 1300.0, "New Description"));
-        assertEquals("Rental not found for update", ex.getMessage());
+        assertEquals("Rental not found for update.", ex.getMessage());
     }
 }


### PR DESCRIPTION
This merge request introduces Swagger (OpenAPI) documentation to improve API usability and visibility.

### Key Changes:

- Added Swagger annotations (@ Operation, @ ApiResponse, @ Schema, etc.) to all REST endpoints.
-  Improved response documentation by defining error handling with a standardized ErrorResponse schema.
- Ensured security-related responses (e.g., 401 Unauthorized, 403 Forbidden) are properly documented in protected endpoints.
-  Enhanced input examples for DTOs, providing better clarity for API consumers.